### PR TITLE
Updated Fuse website link in 'Work with us' section

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,7 +284,7 @@
                     <div class="col-md-8">
                       <p>To transform the charity sector and enable it to put digital at the heart of its work, we need to support senior charity leaders and CEOs to understand the potential of digital.</p>
                       <p>Our Digital Fellowship, funded by Comic Relief, is a carefully constructed learning programme that teaches its fellows the key aspects of the digital development, from paper prototyping to business modelling. We bring the leaders together to learn from industry experts as well as spending time with key organisations leading the field. The programme culminates in a hack for the fellows to put what they've learnt into practice.</p>
-                      <p><a href="https://s3-eu-west-1.amazonaws.com/wearecast.org.uk/assets/Downloads/fellowshipIntroduction.pdf" download class="link">Click here to download more details about the programme</a></p>
+                      <p><a href="https://medium.com/@wearecast/diving-into-the-digital-fellowship-part-1-411119ad5039" class="link">Check out our blog for more details about the programme</a></p>
                     </div>
                   </div>
                 </article>

--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
               <div class="col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2 col-xs-8 col-xs-offset-2">
                 <p>
                   CAST has <a href="https://medium.com/@wearecast/cast-announces-1-12m-funding-from-big-lottery-fund-to-power-nonprofits-with-digital-2bb75ec063fe#.mb633lo45">recently been awarded £1.12m by Big Lottery Fund</a> to help more nonprofits build tech,
-                  following the success of our <a href="http://wearecast.org.uk/fuse">Fuse</a> product accelerator. <br><br>We’ll be sharing details about the 2017 programme
+                  following the success of our <a href="http://wearecast.org.uk/fuse.html">Fuse</a> product accelerator. <br><br>We’ll be sharing details about the 2017 programme
                   later in the year, so please follow us on <a href="https://twitter.com/TechforgoodCAST">Twitter</a>, <a href="https://www.linkedin.com/company/cast-centre-for-the-acceleration-of-social-technology">LinkedIn</a> or <a href="https://medium.com/@wearecast">Medium</a>,
                   and <a href="http://wearecast.org.uk/#footer">sign up to our newsletter</a> so you can be the first to hear more details about it; our applications aren’t open just yet.
                 </p>


### PR DESCRIPTION
My mistake - hadn't realised the Fuse site still had '.html' on the end of it!
